### PR TITLE
ldgen.py is only three dirname levels below IDF_PATH.

### DIFF
--- a/ldgen.py
+++ b/ldgen.py
@@ -45,7 +45,7 @@ createVenv()
   fi
 }
 
-IDF_PATH=$(dirname $(dirname $(dirname $(dirname $0))))
+IDF_PATH=$(dirname $(dirname $(dirname $0)))
 echo "(1023) IDF_PATH is $IDF_PATH"
 export IDF_PATH
 if [ ! -f $IDF_PATH/venv/bin/activate ]; then


### PR DESCRIPTION
Calling ldgen.py generates the wrong IDF_PATH.  In the example below esp-idf is located in /home/christo/fpc/xtensa/test/esp-idf-4.3.2:
```
~/fpc/xtensa/examples/hello-test$ ../../../gitlab-cc/compiler/ppcrossxtensa -n @~/fpc/gitlab-cc/fpc.cfg -Filib/xtensa-linux -Fl../../test/lx6 -Fl../../test/lx6/esp32 -Fu. -FUlib/xtensa-linux -FE. -ohello_ -Tfreertos  -Wpesp32 -FD/home/christo/fpc/xtensa/test/bin -XPxtensa-esp32-elf- -Ff/home/christo/fpc/xtensa/test/esp-idf-4.3.2/ -WP4.3.2 hello
Free Pascal Compiler version 3.3.1 [2022/01/14] for xtensa
Copyright (c) 1993-2022 by Florian Klaempfl and others
Target OS: FreeRTOS
Compiling hello.pp
Assembling hello
(1023) IDF_PATH is /home/christo/fpc/xtensa/test
(1023) refreshing outdated venv, if you see this on every compile then create an issue on https://github.com/michael-ring/espsdk4fpc/issues
Collecting pip
  Using cached pip-21.3.1-py3-none-any.whl (1.7 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 20.0.2
    Uninstalling pip-20.0.2:
      Successfully uninstalled pip-20.0.2
Successfully installed pip-21.3.1
ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/home/christo/fpc/xtensa/test/requirements.txt'
```